### PR TITLE
Initial slide fixes for ICCS summer school 24

### DIFF
--- a/slides/references.bib
+++ b/slides/references.bib
@@ -8,6 +8,19 @@
   year={1999}
 }
 
+@article{atkinson2024practical,
+  author = {Atkinson, Jack and Denholm, Jim},
+  doi = {10.21105/jose.00239},
+  journal = {Journal of Open Source Education},
+  month = jun,
+  number = {76},
+  pages = {239},
+  title = {{Practical machine learning with PyTorch}},
+  url = {https://jose.theoj.org/papers/10.21105/jose.00239},
+  volume = {7},
+  year = {2024}
+}
+
 @article{bi2022pangu,
   title={Pangu-weather: A 3d high-resolution model for fast and accurate global weather forecast},
   author={Bi, Kaifeng and Xie, Lingxi and Zhang, Hengheng and Chen, Xin and Gu, Xiaotao and Tian, Qi},
@@ -84,13 +97,6 @@
   publisher={The Royal Society Publishing}
 }
 
-@article{pathak2022fourcastnet,
-  title={Fourcastnet: A global data-driven high-resolution weather model using adaptive fourier neural operators},
-  author={Pathak, Jaideep and Subramanian, Shashank and Harrington, Peter and Raja, Sanjeev and Chattopadhyay, Ashesh and Mardani, Morteza and Kurth, Thorsten and Hall, David and Li, Zongyi and Azizzadenesheli, Kamyar and others},
-  journal={arXiv preprint arXiv:2202.11214},
-  year={2022}
-}
-
 @inproceedings{ma2021data,
   title={Data-driven discovery of the governing equations describing radiation belt dynamics},
   author={Ma, Donglai and Bortnik, Jacob and Alves, Edurado and Camporeale, Enrico and Chu, Xiangning and Kellerman, Adam},
@@ -98,6 +104,13 @@
   volume={2021},
   pages={SA15B--1928},
   year={2021}
+}
+
+@article{pathak2022fourcastnet,
+  title={Fourcastnet: A global data-driven high-resolution weather model using adaptive fourier neural operators},
+  author={Pathak, Jaideep and Subramanian, Shashank and Harrington, Peter and Raja, Sanjeev and Chattopadhyay, Ashesh and Mardani, Morteza and Kurth, Thorsten and Hall, David and Li, Zongyi and Azizzadenesheli, Kamyar and others},
+  journal={arXiv preprint arXiv:2202.11214},
+  year={2022}
 }
 
 @article{rasp2020weatherbench,

--- a/slides/slides.qmd
+++ b/slides/slides.qmd
@@ -1,6 +1,6 @@
 ---
-title: "Introduction to Machine Learning with PyTorch"
-subtitle: "NCAS & ICCS Summer Schools 2023"
+title: "Introduction to Neural Networks with PyTorch"
+subtitle: "ICCS Summer School 2024"
 format:
   revealjs:
     embed-resources: true
@@ -16,11 +16,40 @@ authors:
     orcid: 0000-0001-5001-4812
     affiliations: ICCS/Cambridge
   - name: Jim Denholm
-    affiliations: Cambridge
+    affiliations: AZ/Cambridge 
     orcid: 0000-0002-2389-3134
+  - name: Matt Archer
+    affiliations: ICCS/Cambridge
+    orcid: 0009-0002-7043-6769
+  - name: Surbhi Goel
+    affiliations: ICCS/Cambridge
+    orcid: 0009-0005-0237-756X
+  
 revealjs-plugins:
   - attribution
 ---
+
+## Rough Schedule {.smaller}
+
+:::: {.columns}
+::: {.column width=50%}
+
+* 9:00-9:30 - NN lecture
+* 9:30-10:30 - Teaching/Code-along
+* 10:30-11:00 - Coffee
+* 11:00-12:00 - Teaching/Code-along
+
+Lunch
+
+* 12:00 - 13:30
+
+::: {style="color: turquoise;"}
+Helping Today:
+
+* Person 1 - Cambridge RSE
+:::
+:::
+::::
 
 <!--
 ## NCAS School (rough) Schedule {.smaller}

--- a/slides/slides.qmd
+++ b/slides/slides.qmd
@@ -31,26 +31,6 @@ revealjs-plugins:
 ---
 
 
-## Material {.smaller}
-
-These slides can be viewed at:
-
-- [https://cambridge-iccs.github.io/practical-ml-with-pytorch](https://cambridge-iccs.github.io/practical-ml-with-pytorch)  
-
-The html and source can be found [on GitHub](https://github.com/Cambridge-ICCS/practical-ml-with-pytorch). Follow this link:
-
-- [https://tinyurl.com/ml-iccs-24](https://tinyurl.com/ml-iccs-24)
-
-\
-\
-Based on the workshop developed by [Jack Atkinson](https://orcid.org/0000-0001-5001-4812) and [Jim Denholm](https://orcid.org/0000-0002-2389-3134):
-
-  - [github.com/Cambridge-ICCS/practical-ml-with-pytorch](https://github.com/Cambridge-ICCS/practical-ml-with-pytorch)
-  - [LICENSE](https://github.com/Cambridge-ICCS/practical-ml-with-pytorch/blob/main/LICENSE)
-
-V1.0 released and JOSE paper accepted: 
-
-  - [@atkinson2024practical]
 
 ## Rough Schedule {.smaller}
 
@@ -74,6 +54,26 @@ Helping Today:
 :::
 ::::
 
+## Material {.smaller}
+
+These slides can be viewed at:
+
+- [https://cambridge-iccs.github.io/practical-ml-with-pytorch](https://cambridge-iccs.github.io/practical-ml-with-pytorch)  
+
+The html and source can be found [on GitHub](https://github.com/Cambridge-ICCS/practical-ml-with-pytorch). Follow this link:
+
+- [https://tinyurl.com/ml-iccs-24](https://tinyurl.com/ml-iccs-24)
+
+\
+\
+Based on the workshop developed by [Jack Atkinson](https://orcid.org/0000-0001-5001-4812) and [Jim Denholm](https://orcid.org/0000-0002-2389-3134):
+
+  - [github.com/Cambridge-ICCS/practical-ml-with-pytorch](https://github.com/Cambridge-ICCS/practical-ml-with-pytorch)
+  - [LICENSE](https://github.com/Cambridge-ICCS/practical-ml-with-pytorch/blob/main/LICENSE)
+
+V1.0 released and JOSE paper accepted: 
+
+  - [@atkinson2024practical]
 <!--
 ## NCAS School (rough) Schedule {.smaller}
 

--- a/slides/slides.qmd
+++ b/slides/slides.qmd
@@ -181,12 +181,12 @@ $$
 :::: {#placeholder}
 ::::
 
-$$m_{n + 1} = -m_{n}\frac{dL}{dm} \cdot l_{r}$$
+$$m_{n + 1} = m_{n} - \frac{dL}{dm} \cdot l_{r}$$
 
 :::: {#placeholder}
 ::::
 
-$$c_{n + 1} = -c_{n}\frac{dL}{dc} \cdot l_{r}$$
+$$c_{n + 1} = c_{n} - \frac{dL}{dc} \cdot l_{r}$$
 
 :::: {#placeholder}
 ::::
@@ -219,7 +219,7 @@ To fit a model we need:
 
 ## Fully-connected neural networks {.smaller}
 
-- The simplest neural networks commonly used are generally called fully-connected nerual nets, dense networks, multi-layer perceptrons, or artifical neural networks (ANNs).
+- The simplest neural networks commonly used are generally called fully-connected neural nets, dense networks, multi-layer perceptrons, or artifical neural networks (ANNs).
 
 :::: {.columns}
 ::: {.column width=40%}
@@ -255,7 +255,7 @@ Image source: [3Blue1Brown](https://www.3blue1brown.com/topics/neural-networks)
 
 # Python and PyTorch {.smaller}
 
-- In this workshop-lecture-thing, we will implement some straightforward neural networks in PyTorch, and use them for different classification and regression problems.
+- In this workshop, we will implement some straightforward neural networks in PyTorch, and use them for different classification and regression problems.
 - PyTorch is a deep learning framework that can be used in both Python and C++.
   - I have never met anyone actually training models in C++; I find it a bit weird.
 - See the PyTorch website: [https://pytorch.org/](https://pytorch.org/)

--- a/slides/slides.qmd
+++ b/slides/slides.qmd
@@ -16,7 +16,7 @@ authors:
     orcid: 0000-0001-5001-4812
     affiliations: ICCS/Cambridge
   - name: Jim Denholm
-    affiliations: AZ/Cambridge 
+    affiliations: Cambridge 
     orcid: 0000-0002-2389-3134
   - name: Matt Archer
     affiliations: ICCS/Cambridge

--- a/slides/slides.qmd
+++ b/slides/slides.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Introduction to Neural Networks with PyTorch"
 subtitle: "ICCS Summer School 2024"
+bibliography: references.bib
 format:
   revealjs:
     embed-resources: true
@@ -12,12 +13,12 @@ format:
     theme: [dark, custom.scss]
     render-on-save: true
 authors:
-  - name: Jack Atkinson
-    orcid: 0000-0001-5001-4812
-    affiliations: ICCS/Cambridge
-  - name: Jim Denholm
-    affiliations: Cambridge 
-    orcid: 0000-0002-2389-3134
+  # - name: Jack Atkinson
+  #   orcid: 0000-0001-5001-4812
+  #   affiliations: ICCS/Cambridge
+  # - name: Jim Denholm
+  #   affiliations: Cambridge 
+  #   orcid: 0000-0002-2389-3134
   - name: Matt Archer
     affiliations: ICCS/Cambridge
     orcid: 0009-0002-7043-6769
@@ -28,6 +29,28 @@ authors:
 revealjs-plugins:
   - attribution
 ---
+
+
+## Material {.smaller}
+
+These slides can be viewed at:
+
+- [https://cambridge-iccs.github.io/practical-ml-with-pytorch](https://cambridge-iccs.github.io/practical-ml-with-pytorch)  
+
+The html and source can be found [on GitHub](https://github.com/Cambridge-ICCS/practical-ml-with-pytorch). Follow this link:
+
+- [https://tinyurl.com/ml-iccs-24](https://tinyurl.com/ml-iccs-24)
+
+\
+\
+Based on the workshop developed by [Jack Atkinson](https://orcid.org/0000-0001-5001-4812) and [Jim Denholm](https://orcid.org/0000-0002-2389-3134):
+
+  - [github.com/Cambridge-ICCS/practical-ml-with-pytorch](https://github.com/Cambridge-ICCS/practical-ml-with-pytorch)
+  - [LICENSE](https://github.com/Cambridge-ICCS/practical-ml-with-pytorch/blob/main/LICENSE)
+
+V1.0 released and JOSE paper accepted: 
+
+  - [@atkinson2024practical]
 
 ## Rough Schedule {.smaller}
 
@@ -434,22 +457,46 @@ $$
 - In short, the model must learn to estimate $x_{\text{c}}$, $y_{\text{c}}$, $r_{x}$ and $r_{y}$.
 
 
-# Further information
+<!-- # Further information -->
 
-## Slides
+<!-- ## Slides
 
 These slides can be viewed at:  
 [https://cambridge-iccs.github.io/practical-ml-with-pytorch](https://cambridge-iccs.github.io/practical-ml-with-pytorch)  
 
-The html and source can be found [on GitHub](https://github.com/Cambridge-ICCS/practical-ml-with-pytorch).
+The html and source can be found [on GitHub](https://github.com/Cambridge-ICCS/practical-ml-with-pytorch). -->
 
 
 ## Contact {.smaller}
 
 For more information we can be reached at:
 
-:::: {.columns}
-::: {.column width="50%"}
+:::: {.columns style="font-size: 60%"}
+::: {.column width="25%"}
+
+{{< fa pencil >}} \ Matt Archer
+
+{{< fa solid person-digging >}} \ [ICCS/UoCambridge](https://iccs.cam.ac.uk/about-us/our-team)
+
+{{< fa solid envelope >}} \ [ma595[AT]cam.ac.uk](mailto:ma595@cam.ac.uk)
+
+{{< fa brands github >}} \ [ma595](https://github.com/ma595)
+
+:::
+
+::: {.column width="25%"}
+
+{{< fa pencil >}} \ Surbhi Goel
+
+{{< fa solid person-digging >}} \ [ICCS/UoCambridge](https://iccs.cam.ac.uk/about-us/our-team)
+
+{{< fa solid envelope >}} \ [sg2147[AT]cam.ac.uk](mailto:sg2147@cam.ac.uk)
+
+{{< fa brands github >}} \ [surbhigoel77](https://github.com/surbhigoel77)
+
+:::
+
+::: {.column width="25%"}
 
 {{< fa pencil >}} \ Jack Atkinson
 
@@ -465,7 +512,7 @@ For more information we can be reached at:
 
 :::
 
-::: {.column width="50%"}
+::: {.column width="25%"}
 
 {{< fa pencil >}} \ Jim Denholm
 


### PR DESCRIPTION
This PR fixes minimal aspects of the workshop's accompanying slides in readiness for the 2024 edition of the ICCS summer school. There is scope to add more.

I have added Surbhi and I as additional authors. I would like to emphasise that we are teaching the session, if possible. @jatkinson1000 do you you have any formatting suggestions?

- [x] Fix the parameter update rule. See https://en.wikipedia.org/wiki/Stochastic_gradient_descent
- [x] Various spelling and style changes
- [x] Modify names of presenters, and acknowledge Jim and Jack. 
- [x] Create 'material' slide that points to github link and cites Jack and Jim's code and JOSE paper.
- [x] Amend contact with two additional columns. 

Closes part of #61 